### PR TITLE
[Feat] 포트폴리오 메인 페이지 및 라우팅 구성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,25 +1,15 @@
-import logo from './logo.svg';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import './App.css';
+import Portfolio from './pages/Portfolio';
 
 function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+    return (
+        <BrowserRouter>
+            <Routes>
+                <Route path="/" element={<Portfolio />} />
+            </Routes>
+        </BrowserRouter>
+    );
 }
 
 export default App;

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as P from './PortfolioStyles.js';
+import Header from '../components/Header.jsx';
+import Aboutme from '../components/Aboutme.jsx';
+import Activity from '../components/Activity.jsx';
+import Project1 from '../components/Projects1.jsx';
+import Project2 from '../components/Projects2.jsx';
+import Project3 from '../components/Projects3.jsx';
+import Project4 from '../components/Projects4.jsx';
+import Skills from '../components/Skills.jsx';
+import Study1 from '../components/Study1.jsx';
+import Study2 from '../components/Study2.jsx';
+import Study3 from '../components/Study3.jsx';
+import Study4 from '../components/Study4.jsx';
+import Contact from '../components/Contact.jsx';
+import Footer from '../components/Footer.jsx';
+
+const Portfolio = () => {
+    return (
+        <P.Container>
+            <Header />
+            <Aboutme />
+            <P.Activity>ACTIVITY</P.Activity>
+            <Activity />
+            <P.Projects>PROJECTS</P.Projects>
+            <Project1 />
+            <Project2 />
+            <Project3 />
+            <Project4 />
+            <P.Skills>SKILLS</P.Skills>
+            <Skills />
+            <P.Study>STUDY</P.Study>
+            <Study1 />
+            <Study2 />
+            <Study3 />
+            <Study4 />
+            <P.Contact>CONTACT</P.Contact>
+            <Contact />
+            <Footer />
+        </P.Container>
+    );
+};
+export default Portfolio;

--- a/src/pages/PortfolioStyles.js
+++ b/src/pages/PortfolioStyles.js
@@ -1,0 +1,40 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    position: relative;
+    margin: 0 auto;
+    width: 100%;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+`;
+
+export const Activity = styled.div`
+    font-size: 35px;
+    margin-top: 10%;
+    margin-bottom: 3%;
+`;
+
+export const Projects = styled.div`
+    font-size: 35px;
+    margin-top: 10%;
+    margin-bottom: 3%;
+`;
+
+export const Skills = styled.div`
+    font-size: 35px;
+    margin-top: 10%;
+    margin-bottom: 3%;
+`;
+
+export const Study = styled.div`
+    font-size: 35px;
+    margin-top: 10%;
+    margin-bottom: 3%;
+`;
+
+export const Contact = styled(Skills)``;


### PR DESCRIPTION
# [feature/portfolio] 포트폴리오 메인 페이지 및 라우팅 구성

## PR요약

해당 pr은
-   포트폴리오 메인 페이지를 구성하고, `/` 경로에 해당 페이지가 렌더링되도록 라우팅을 설정한 작업입니다.

## 관련 이슈

related to #1 

## 작업 내용

-   `App.js`에 `react-router-dom`을 이용해 `BrowserRouter` 및 `Route` 설정
    -  ` /` 경로로 접속 시 `Portfolio` 페이지가 렌더링되도록 구성
    -   어떻게 개선했는지
-   `pages/Portfolio.jsx`에서 메인 콘텐츠 레이아웃 구성
    -   Header, About, Activity, Projects, Skills, Study, Contact, Footer 컴포넌트 연결
    -   각각의 영역 제목을 `styled-components`로 스타일링 (`PortfolioStyles.js`)
-   페이지 전체를 감싸는 `Container`와 각 섹션별 제목 스타일(`Activity`, `Projects` 등) 정의

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?