### PR TITLE
[Chore] 이슈 템플릿 메타 정보 수정 (공통 템플릿 이름 및 설명 변경)

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue_template.yml
@@ -1,49 +1,48 @@
-name: 기능 유지보수 및 구조 개선 (기준 이슈)
-about: 특정 화면 또는 기능의 유지보수, 구조 개선, 스타일링 등을 포괄적으로 관리하기 위한 기준 이슈입니다.
-title: "[Feature] "
-labels: ["enhancement", "epic"]
+name: 공통 이슈 템플릿
+description: 모든 화면 및 기능에 사용할 기본 이슈 템플릿입니다.
+title: '[Feature] '
+labels: ['enhancement', 'epic']
 assignees: []
 
 body:
+    - type: markdown
+      attributes:
+      value: | ## 📝 이슈 제목 가이드
+          이슈 제목은 다음 형식을 따라주세요: **[태그] 간단한 설명**
 
--   type: markdown
-    attributes:
-    value: | ## 📝 이슈 제목 가이드  
-     이슈 제목은 다음 형식을 따라주세요: **[태그] 간단한 설명**
+             예시:
+             - [Fix] 로그인 시 오류 발생 현상
+             - [Feat] 프로필 이미지 업로드 기능 요청
+             - [Refactor] 마이페이지 레이아웃 구조 개선
 
-        예시:
-        - [Fix] 로그인 시 오류 발생 현상
-        - [Feat] 프로필 이미지 업로드 기능 요청
-        - [Refactor] 마이페이지 레이아웃 구조 개선
+             ---
 
-        ---
+             아래 내용을 채워주세요.
 
-        아래 내용을 채워주세요.
+    - type: markdown
+      attributes:
+      value: | ## 📝 개요
+          이 이슈는 특정 기능/화면에 대한 UI 구조, 레이아웃, 스타일, 마크업, 컴포넌트 개선 작업 등을 포괄적으로 관리하기 위한 **기준 이슈(Epic)**입니다.
 
--   type: markdown
-    attributes:
-    value: | ## 📝 개요  
-     이 이슈는 특정 기능/화면에 대한 UI 구조, 레이아웃, 스타일, 마크업, 컴포넌트 개선 작업 등을 포괄적으로 관리하기 위한 **기준 이슈(Epic)**입니다.
+    - type: markdown
+      attributes:
+      value: | ## 📌 포함 범위 예시
+          - 섹션 추가/삭제/위치 조정  
+          - 스타일 수정 또는 스타일 파일 구조 개선  
+          - 마크업 정리 및 시멘틱 구조 반영  
+          - 반응형 대응, 접근성 향상  
+          - 텍스트/콘텐츠 수정  
+          - 인터랙션 추가 (스크롤, hover 등)  
+          - 관련 컴포넌트 추가 및 리팩터링
 
--   type: markdown
-    attributes:
-    value: | ## 📌 포함 범위 예시  
-     - 섹션 추가/삭제/위치 조정  
-     - 스타일 수정 또는 스타일 파일 구조 개선  
-     - 마크업 정리 및 시멘틱 구조 반영  
-     - 반응형 대응, 접근성 향상  
-     - 텍스트/콘텐츠 수정  
-     - 인터랙션 추가 (스크롤, hover 등)  
-     - 관련 컴포넌트 추가 및 리팩터링
+    - type: markdown
+      attributes:
+      value: | ## 🔗 활용 방식
+          - 관련 PR에 `related to #이슈번호` 또는 `closes #이슈번호`로 연결  
+          - 세부 작업은 별도 이슈로 분리하여 이 이슈와 링크로 연결 관리
 
--   type: markdown
-    attributes:
-    value: | ## 🔗 활용 방식  
-     - 관련 PR에 `related to #이슈번호` 또는 `closes #이슈번호`로 연결  
-     - 세부 작업은 별도 이슈로 분리하여 이 이슈와 링크로 연결 관리
-
--   type: markdown
-    attributes:
-    value: | ## 🎯 목적  
-     - 특정 기능/페이지에 대한 유지보수 작업을 **흐름 단위**로 추적  
-     - 관련 PR과 이슈를 **일관된 히스토리**로 묶어 관리
+    - type: markdown
+      attributes:
+      value: | ## 🎯 목적
+          - 특정 기능/페이지에 대한 유지보수 작업을 **흐름 단위**로 추적  
+          - 관련 PR과 이슈를 **일관된 히스토리**로 묶어 관리


### PR DESCRIPTION
# [chore/github-config] 이슈 템플릿 메타 정보 수정 (공통 템플릿 이름 및 설명 변경)

## PR요약

해당 pr은
-   기존 이슈 템플릿의 메타 정보 (`name`, `about`, `title`, `labels`)를 수정했습니다.
-   보다 범용적으로 사용 가능한 공통 이슈 템플릿으로 리네이밍하고, 최신 GitHub Issue Forms 형식에 맞게 구조를 정비한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   `.github/ISSUE_TEMPLATE/general_issue_template.yml` 파일 수정
    -   `name`: 기존 `"기능 유지보수 및 구조 개선 (기준 이슈)"` → `"공통 이슈 템플릿"`으로 변경
    -   `about`: Markdown 기반에서 쓰던 `about` 필드를 제거하고, Issue Forms 형식에 맞는 `description:` 필드로 변경
    -   `description:` 모든 기능/화면에 적용 가능하도록 설정 문구 변경
    -   `title`, `labels`: 기본값 유지 (`[Feature]`, `enhancement`, `epic`)

## 공유사항

-   GitHub Issue Forms 형식에 맞추기 위해 `about` → `description` 전환이 필요했으며, 이는 GitHub 공식 문서 기준입니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
