### PR TITLE
[Feat] 상단 네비게이션 Header 컴포넌트 추가

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import * as H from './HeaderStyles.js';
+
+const Header = () => {
+    const navigate = useNavigate();
+
+    const handleAboutme = () => {
+        navigate();
+    };
+
+    const handleActivity = () => {
+        navigate();
+    };
+
+    const handleProject = () => {
+        navigate();
+    };
+
+    const handleSkills = () => {
+        navigate();
+    };
+
+    const handleContact = () => {
+        navigate();
+    };
+
+    return (
+        <H.Container>
+            <H.Left>
+                <H.Name>Kim Jinseon</H.Name>
+            </H.Left>
+            <H.Right>
+                <H.Aboutme>About me</H.Aboutme>
+                <H.Activity>Activity</H.Activity>
+                <H.Project>Project</H.Project>
+                <H.Skills>Skills</H.Skills>
+                <H.Contact>Contact</H.Contact>
+            </H.Right>
+        </H.Container>
+    );
+};
+export default Header;

--- a/src/components/HeaderStyles.js
+++ b/src/components/HeaderStyles.js
@@ -1,0 +1,45 @@
+import { styled } from 'styled-components';
+
+export const Container = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 2%;
+    box-sizing: border-box;
+`;
+
+export const Left = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const Right = styled.div`
+    display: flex;
+    gap: 20px;
+    align-items: center;
+`;
+
+export const Name = styled.div`
+    font-weight: bold;
+`;
+
+export const Aboutme = styled.div`
+    cursor: pointer;
+`;
+
+export const Activity = styled.div`
+    cursor: pointer;
+`;
+
+export const Project = styled.div`
+    cursor: pointer;
+`;
+
+export const Skills = styled.div`
+    cursor: pointer;
+`;
+
+export const Contact = styled.div`
+    cursor: pointer;
+`;


### PR DESCRIPTION
# [feature/header] 상단 네비게이션 Header 컴포넌트 추가

## PR요약

해당 pr은
-   상단 네비게이션 영역에 사용될 Header 컴포넌트를 새롭게 추가한 작업입니다.
-   페이지 내 각 섹션으로 이동 가능한 메뉴 버튼 구조를 포함하고 있으며, 레이아웃 및 스타일링이 적용되어 있습니다.

## 관련 이슈

없음

## 작업 내용

-   `Header.jsx` 컴포넌트 추가
    -   이름 영역과 네비게이션 메뉴 영역 분리
    -   메뉴 항목: About me, Activity, Project, Skills, Contact
-   `HeaderStyles.js` 작성
    -   전체 컨테이너 스타일 구성
    -   각 메뉴 항목 및 이름에 대한 스타일링 적용

## 공유사항

-   현재 메뉴 클릭 시 `navigate()`에 경로가 전달되지 않아 실제 이동 기능은 미구현 상태입니다. 
-   메뉴 항목에 대한 hover 효과나 스크롤 연동 기능은 향후 추가 예정입니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
