### PR TITLE
[Fix] Container 너비 조정 및 내부 레이아웃 정렬 오류 수정

### DIFF
--- a/src/components/AboutmeStyles.js
+++ b/src/components/AboutmeStyles.js
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 export const Container = styled.div`
-    width: 90%;
+    width: 70%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -14,13 +14,15 @@ export const Container = styled.div`
 
 export const TopGroup = styled.div`
     display: flex;
-    gap: 100px;
+    flex-wrap: wrap;
+    gap: 40px;
     align-items: flex-start;
 `;
 
 export const BottomGroup = styled.div`
     display: flex;
-    gap: 100px;
+    flex-wrap: wrap;
+    gap: 40px;
     align-items: flex-start;
     margin-top: 10%;
 `;


### PR DESCRIPTION
# [feature/aboutme] Container 너비 조정 및 내부 레이아웃 정렬 오류 수정

## PR요약

해당 pr은
-   Aboutme 컴포넌트의 Container 너비를 기존 90%에서 70%로 조정했습니다.
-   내부 요소(텍스트 및 이미지)의 정렬이 Container를 벗어나는 문제를 해결한 작업입니다.

## 관련 이슈

related to #14 

## 작업 내용

-   `AboutmeStyles.js`
    -   Container 너비를 `90%` → `70%`로 변경하여 다른 섹션과 레이아웃 통일
    -   `TopGroup`, `BottomGroup`에 `flex-wrap: wrap` 추가

## 공유사항

-   향후 모바일 대응을 위해 미디어 쿼리 추가도 고려하면 좋을 것 같습니다.

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [x] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
