### PR TITLE
[Fix] Skills 컴포넌트 Container 및 이미지 크기 조정, 레이아웃 넘침 문제 수정

### DIFF
--- a/src/components/SkillsStyles.js
+++ b/src/components/SkillsStyles.js
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 
 export const Container = styled.div`
-    width: 90%;
+    width: 70%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -14,17 +14,20 @@ export const Container = styled.div`
 
 export const RowTop = styled.div`
     display: flex;
+    flex-wrap: wrap;
     gap: 30px;
 `;
 
 export const RowMiddle = styled.div`
     display: flex;
+    flex-wrap: wrap;
     gap: 30px;
     margin-top: 3%;
 `;
 
 export const RowBottom = styled.div`
     display: flex;
+    flex-wrap: wrap;
     gap: 30px;
     align-items: flex-start;
     margin-top: 3%;
@@ -35,8 +38,8 @@ export const SkillIcon = styled.div`
     display: inline-block;
 
     img {
-        width: 80px;
-        height: 80px;
+        width: 60px;
+        height: 60px;
         transition: filter 0.3s;
     }
 
@@ -55,8 +58,8 @@ export const SkillIconPWA = styled.div`
     display: inline-block;
 
     img {
-        width: 170px;
-        height: 80px;
+        width: 150px;
+        height: 60px;
         transition: filter 0.3s;
     }
 


### PR DESCRIPTION
# [feature/skills] Skills 컴포넌트 Container 및 이미지 크기 조정, 레이아웃 넘침 문제 수정

## PR요약

해당 pr은
-   Skills 컴포넌트의 Container 크기와 내부 이미지 크기를 조정했습니다.
-   이미지와 텍스트가 영역을 벗어나는 레이아웃 문제를 수정했습니다.

## 관련 이슈

related to #10 

## 작업 내용

-   `Container` 너비 축소 (`width: 90%` → `70%`)로 전체 레이아웃 일관성 확보
-   `SkillIcon`, `SkillIconPWA` 내부 이미지 크기 축소 (`80px` → `60px`, `170px` → `150px`)
-   `flex-wrap` 적용 및 `gap` 조정으로 이미지와 텍스트가 Container 밖으로 빠져나가지 않도록 수정
-   Skills 내부 Row 레이아웃이 모바일이나 좁은 화면에서 깨지지 않도록 기본 유연성 확보

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
