### PR TITLE
[Style] 헤더 고정 및 메뉴 hover 효과 추가

### DIFF
--- a/src/components/HeaderStyles.js
+++ b/src/components/HeaderStyles.js
@@ -1,6 +1,10 @@
 import { styled } from 'styled-components';
 
 export const Container = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
     width: 100%;
     display: flex;
     justify-content: space-between;
@@ -12,12 +16,14 @@ export const Container = styled.div`
 export const Left = styled.div`
     display: flex;
     align-items: center;
+    font-size: 22px;
 `;
 
 export const Right = styled.div`
     display: flex;
     gap: 20px;
     align-items: center;
+    font-size: 18px;
 `;
 
 export const Name = styled.div`
@@ -26,24 +32,54 @@ export const Name = styled.div`
 
 export const Aboutme = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;
 
 export const Activity = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;
 
 export const Project = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;
 
 export const Skills = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;
 
 export const Study = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;
 
 export const Contact = styled.div`
     cursor: pointer;
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+        color: #ff4c52;
+    }
 `;


### PR DESCRIPTION
# [feature/header] 헤더 고정 및 메뉴 hover 효과 추가

## PR요약

해당 pr은
-   웹사이트 헤더가 스크롤 시에도 항상 상단에 고정되도록 수정했습니다.
-   헤더 내 메뉴 항목에 hover 효과를 추가하여 버튼처럼 보이도록 시각적 개선을 진행한 작업입니다.

## 관련 이슈

없음

## 작업 내용

-   헤더 위치 고정
    -   `HeaderStyles.js`의 `Container`에 `position: fixed`, `top: 0`, `z-index: 1000` 적용
    -   어느 위치에서든 헤더가 상단에 고정되도록 개선
-   메뉴 항목 hover 스타일 추가
    -   `Aboutme`, `Activity`, `Project`, `Skills`, `Study`, `Contact` 등에 `transition` 및 `hover 색상 변화 (#ff4c52)` 적용
    -   시각적으로 버튼처럼 보이도록 인터랙션 개선
-   글자 크기 조정
    -   `Left` (이름 영역): 22px
    -   `Right` (메뉴 영역): 18px

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [ ] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
