### PR TITLE
[Style] Pretendard 글로벌 폰트 적용 및 전역 스타일 설정

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import './App.css';
+import GlobalStyles from './common/GlobalStyles';
 import Portfolio from './pages/Portfolio';
 
 function App() {
     return (
         <BrowserRouter>
+            <GlobalStyles />
             <Routes>
                 <Route path="/" element={<Portfolio />} />
             </Routes>

--- a/src/common/GlobalStyles.js
+++ b/src/common/GlobalStyles.js
@@ -1,0 +1,18 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`  
+
+    @font-face {
+        font-family: 'Pretendard-Regular';
+        src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+        font-weight: 400;
+        font-style: normal;
+    }
+
+    * {
+    font-family: 'Pretendard-Regular', sans-serif;
+    }
+
+`;
+
+export default GlobalStyle;


### PR DESCRIPTION
# [feature/portfolio] Pretendard 글로벌 폰트 적용 및 전역 스타일 설정

## PR요약

해당 pr은
-   포트폴리오 프로젝트 전반에 사용할 글로벌 폰트를 설정하고, 전역 스타일(GlobalStyle)을 적용하여 전체적인 UI 일관성을 확보한 작업입니다.

## 관련 이슈

related to #1 

## 작업 내용

-   글로벌 스타일 파일(`GlobalStyles.js`) 생성
    -   Pretendard-Regular 폰트를 `@font-face`로 정의
    -   `*` 선택자에 `font-family` 적용
-   `App.js`에 `<GlobalStyles />` 컴포넌트 삽입
    -   전체 페이지에 글로벌 스타일 적용되도록 설정

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
