### PR TITLE
[Fix] Intro 컴포넌트에서 이미지와 텍스트 간격 조정

### DIFF
--- a/src/components/Intro.jsx
+++ b/src/components/Intro.jsx
@@ -7,9 +7,7 @@ const Intro = () => {
         <I.Container>
             <I.Content>
                 <I.Images>
-                    <I.ImageRow>
-                        <img src={Me} />
-                    </I.ImageRow>
+                    <img src={Me} />
                 </I.Images>
                 <I.Text>
                     안녕하세요. <br />

--- a/src/components/IntroStyles.js
+++ b/src/components/IntroStyles.js
@@ -24,20 +24,16 @@ export const Content = styled.div`
 export const Images = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    flex: 1;
-`;
-
-export const ImageRow = styled.div`
-    display: flex;
-    gap: 10px;
-    align-items: center;
+    width: 200px;
+    img {
+        width: 100%;
+        border-radius: 50%;
+    }
 `;
 
 export const Text = styled.div`
-    flex: 1;
+    margin-left: 40px;
     font-size: 20px;
     text-align: left;
-    margin-left: -25%;
     justify-content: center;
 `;


### PR DESCRIPTION
# [feature/intro] Intro 컴포넌트에서 이미지와 텍스트 간격 조정

## PR요약

해당 pr은
-   Intro 컴포넌트에서 이미지와 텍스트 사이의 간격이 너무 넓게 표시되던 문제를 해결하기 위한 레이아웃 개선 작업입니다. 보다 균형 잡힌 화면 구성을 위해 간격을 조정했습니다.

## 관련 이슈

related to #14 

## 작업 내용

-   `IntroStyles.js`에서 `Images` 컴포넌트의 `width`를 고정값(200px)으로 설정하고, `Text` 컴포넌트에 적용된 `margin-left` 값을 조정하여 불필요하게 넓었던 간격을 축소함

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
