### PR TITLE
[Refactor] 불필요한 이미지 크기 관련 코드 제거

### DIFF
--- a/src/components/StudyStyles.js
+++ b/src/components/StudyStyles.js
@@ -12,6 +12,11 @@ export const Container = styled.div`
     box-shadow: 0px 10px 40px rgba(0, 0, 0, 0.2);
     margin: 0 auto;
     margin-bottom: 6%;
+
+    @media (max-width: 768px) {
+        width: 90%;
+        padding: 8% 5%;
+    }
 `;
 
 export const Content = styled.div`
@@ -20,6 +25,12 @@ export const Content = styled.div`
     flex-direction: row;
     gap: 0px;
     width: 100%;
+
+    @media (max-width: 768px) {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
 `;
 
 export const Images = styled.div`
@@ -27,18 +38,37 @@ export const Images = styled.div`
     flex-direction: column;
     gap: 10px;
     flex: 1;
+
+    @media (max-width: 768px) {
+        margin-bottom: 1.5rem;
+    }
 `;
 
 export const ImageRow = styled.div`
     display: flex;
     gap: 10px;
     align-items: center;
+    justify-content: center;
+
+    img {
+        height: auto;
+
+        @media (max-width: 768px) {
+            max-width: 70px;
+        }
+    }
 `;
 
 export const Text = styled.div`
     flex: 1;
     font-size: 15px;
     text-align: left;
+
+    @media (max-width: 768px) {
+        font-size: 14px;
+        width: 90%;
+        margin: 0 auto;
+    }
 `;
 
 export const LastText = styled.div`
@@ -54,5 +84,11 @@ export const LastText = styled.div`
 
     a:hover {
         text-decoration: underline;
+    }
+
+    @media (max-width: 768px) {
+        font-size: 14px;
+        width: 90%;
+        margin: 0 auto;
     }
 `;


### PR DESCRIPTION
# [feature/study] 불필요한 이미지 크기 관련 코드 제거

## PR요약

해당 pr은
-   Study 섹션의 스타일 파일(`StudyStyles.js`)에서 이미지 크기 관련 스타일을 제거했습니다.

## 관련 이슈

related to #12 

## 작업 내용

-   `img`에 설정된 불필요한 `max-width: 100px;` 제거

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
