### PR TITLE
[Fix] Intro 영역 가운데 정렬 안 되는 문제 수정

### DIFF
--- a/src/components/IntroStyles.js
+++ b/src/components/IntroStyles.js
@@ -17,6 +17,7 @@ export const Container = styled.div`
 export const Content = styled.div`
     display: flex;
     align-items: center;
+    justify-content: center;
     flex-direction: row;
     width: 100%;
 `;


### PR DESCRIPTION
# [feature/intro] Intro 영역 가운데 정렬 안 되는 문제 수정

## PR요약

해당 pr은
-   Intro 컴포넌트 내 이미지와 텍스트 묶음(Content 영역)이 시각적으로 가운데 정렬되지 않던 문제를 해결한 작업입니다.
-   `justify-content: center;`를 추가하여 요소들을 `Container` 내에서 정확히 중앙 정렬되도록 수정했습니다.

## 관련 이슈

related to #14 

## 작업 내용

-   Intro 컴포넌트의 `Content` styled-component에 `justify-content: center;` 속성 추가
    -   기존에는 이미지와 텍스트가 좌측 정렬처럼 보여 시각적으로 균형이 맞지 않았음
    -   해당 속성 추가로 이미지와 텍스트 묶음이 `Container` 기준으로 수평 가운데 배치되도록 개선

## 공유사항

없음

## PR등록 전 체크리스트

-   [x] 고치거나 추가한 부분이 정상적으로 동작하는가?
-   [x] 작업 내용 기재
-   [x] PR 요약 기재
-   [x] 관련 이슈 기재
-   [ ] 공유사항 기재
-   [x] 비밀파일을 업로드 하지는 않았는가?
